### PR TITLE
deps-dev(deps-dev): bump js-yaml from 4.1.0 to 4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1032,13 +1032,6 @@
         "tailwindcss": "4.1.17"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
-      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.1.17",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.17.tgz",
@@ -1353,13 +1346,6 @@
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.17"
       }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
-      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
@@ -4431,9 +4417,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## 概要
開発依存関係である js-yaml を 4.1.0 から 4.1.1 にアップデートします。

## 変更内容
- js-yaml を 4.1.0 から 4.1.1 にバージョンアップ
- package-lock.json 内の重複した tailwindcss のエントリを削除

## テスト
- [ ] ビルドが正常に完了することを確認
- [ ] 既存のテストが全て合格することを確認
- [ ] 依存関係の整合性を確認

## 関連 Issue
依存関係の定期的な更新

## チェックリスト
- [ ] CI/CD が正常に動作することを確認
- [ ] セキュリティ脆弱性がないことを確認