### PR TITLE
refactor: ライト/ダークモード画像切り替えコンポーネントを共通化

### DIFF
--- a/src/app/skill/github/page.tsx
+++ b/src/app/skill/github/page.tsx
@@ -2,6 +2,31 @@ import Link from 'next/link'
 import Image from 'next/image'
 import { ArrowLeft, Star, GitFork, ExternalLink } from 'lucide-react'
 
+function DarkModeStatsImage({
+  lightSrc,
+  darkSrc,
+  alt,
+  width,
+  height,
+}: {
+  lightSrc: string
+  darkSrc: string
+  alt: string
+  width: number
+  height: number
+}) {
+  return (
+    <>
+      <div className="block dark:hidden">
+        <Image src={lightSrc} alt={`${alt} (Light)`} width={width} height={height} className="w-full h-auto" unoptimized />
+      </div>
+      <div className="hidden dark:block">
+        <Image src={darkSrc} alt={`${alt} (Dark)`} width={width} height={height} className="w-full h-auto" unoptimized />
+      </div>
+    </>
+  )
+}
+
 interface Repository {
   id: number
   name: string
@@ -72,53 +97,23 @@ export default async function GitHubSkillPage() {
       <div className="grid md:grid-cols-2 gap-6 mb-12">
         <div className="space-y-4">
           <h2 className="text-xl font-bold text-gray-900 dark:text-white">GitHub Stats</h2>
-          {/* Light Mode */}
-          <div className="block dark:hidden">
-            <Image
-              src="https://github-readme-stats.vercel.app/api?username=KOU050223&show_icons=true&theme=default&rank_icon=github"
-              alt="GitHub Stats (Light)"
-              width={495}
-              height={195}
-              className="w-full h-auto"
-              unoptimized
-            />
-          </div>
-          {/* Dark Mode */}
-          <div className="hidden dark:block">
-            <Image
-              src="https://github-readme-stats.vercel.app/api?username=KOU050223&show_icons=true&theme=dark&rank_icon=github&bg_color=111827&title_color=fff&text_color=9ca3af&icon_color=3b82f6&border_color=374151"
-              alt="GitHub Stats (Dark)"
-              width={495}
-              height={195}
-              className="w-full h-auto"
-              unoptimized
-            />
-          </div>
+          <DarkModeStatsImage
+            lightSrc="https://github-readme-stats.vercel.app/api?username=KOU050223&show_icons=true&theme=default&rank_icon=github"
+            darkSrc="https://github-readme-stats.vercel.app/api?username=KOU050223&show_icons=true&theme=dark&rank_icon=github&bg_color=111827&title_color=fff&text_color=9ca3af&icon_color=3b82f6&border_color=374151"
+            alt="GitHub Stats"
+            width={495}
+            height={195}
+          />
         </div>
         <div className="space-y-4">
           <h2 className="text-xl font-bold text-gray-900 dark:text-white">Top Languages</h2>
-          {/* Light Mode */}
-          <div className="block dark:hidden">
-            <Image
-              src="https://github-readme-stats.vercel.app/api/top-langs/?username=KOU050223&layout=compact&theme=default"
-              alt="Top Languages (Light)"
-              width={300}
-              height={165}
-              className="w-full h-auto"
-              unoptimized
-            />
-          </div>
-          {/* Dark Mode */}
-          <div className="hidden dark:block">
-            <Image
-              src="https://github-readme-stats.vercel.app/api/top-langs/?username=KOU050223&layout=compact&theme=dark&bg_color=111827&title_color=fff&text_color=9ca3af&border_color=374151"
-              alt="Top Languages (Dark)"
-              width={300}
-              height={165}
-              className="w-full h-auto"
-              unoptimized
-            />
-          </div>
+          <DarkModeStatsImage
+            lightSrc="https://github-readme-stats.vercel.app/api/top-langs/?username=KOU050223&layout=compact&theme=default"
+            darkSrc="https://github-readme-stats.vercel.app/api/top-langs/?username=KOU050223&layout=compact&theme=dark&bg_color=111827&title_color=fff&text_color=9ca3af&border_color=374151"
+            alt="Top Languages"
+            width={300}
+            height={165}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## 概要 📝

/simplify

issue: #

GitHub StatsページでライトモードとダークモードのStatistics画像を表示する際に、同一パターンのコードが2箇所で重複していたため、共通コンポーネントに抽出しました。

## 変更内容 🔨

- `DarkModeStatsImage` コンポーネントを `src/app/skill/github/page.tsx` 内に追加
- GitHub Stats・Top Languages の画像表示部分（各2ブロック）を新コンポーネントで置き換え
- ロジックの変更はなし

## スクリーンショット 📸

| Before | After |
| :---: | :---: |
| (変更なし) | (変更なし) |

## 動作確認 🧪

1. `npm run build` が正常に通ることを確認

## チェックリスト ✅

- [x] 自身のコードをセルフレビューしました
- [ ] 関連するドキュメント（README.mdなど）を更新しました
- [x] 正常にビルドが通ることを確認しました
- [ ] 新規で追加した機能には、必要なテストコードを追加しました

## 備考 💬

コードの動作は変わらず、保守性の向上が目的のリファクタリングです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * GitHub 統計表示のライト/ダークモード対応を統合し、画像表示ロジックを整理して重複を削減しました。  
  * 表示される画像やテキスト、寸法、動作に変更はなく、ユーザー目に見える挙動は維持されています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->